### PR TITLE
Slash the file strings so the regex works in the string search on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,9 @@ module.exports = function(file, options) {
       var ext = path.extname(file.path);
       if (ext.toLowerCase() == '.scss' || ext.toLowerCase() == '.sass') {
         // Remove the parent file base path from the path we will output.
-        var filename = path.normalize(file.path);
-        var cwd = path.normalize(file.cwd);
+        // Slash the file strings so the regex works in the string search on Windows
+        var filename = slash(path.normalize(file.path));
+        var cwd = slash(path.normalize(file.cwd));
         var cwdfile = (filename.substr(filename.search(cwd))).replace(cwd, '');
         var importname = (cwdfile.replace(/\.(scss|sass)$/, '')).replace('/_', '/');
         if (importname.charAt(0) === '/') {


### PR DESCRIPTION
Hi Marc, trying to use this on Windows and running into `filename.search(cwd)` returning
-1 for what should match on Windows because of `\` as path separator.  Chops the path
in the generated imports. There's probably other ways, but seemed an easy fix just to convert to forward slashes where search then works fine.  Thanks for considering this PR. --Brian