### PR TITLE
Fix for Win10

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,8 @@ module.exports = function(file, options) {
       var ext = path.extname(file.path);
       if (ext.toLowerCase() == '.scss' || ext.toLowerCase() == '.sass') {
         // Remove the parent file base path from the path we will output.
-        var filename = path.normalize(file.path);
-        var cwd = path.normalize(file.cwd);
+        var filename = slash(path.normalize(file.path));
+        var cwd = slash(path.normalize(file.cwd));
         var cwdfile = (filename.substr(filename.search(cwd))).replace(cwd, '');
         var importname = (cwdfile.replace(/\.(scss|sass)$/, '')).replace('/_', '/');
         if (importname.charAt(0) === '/') {


### PR DESCRIPTION
Hi Marc, we're trying to use this on Windows but looks like it doesn't work.
After debugging the source code of the package, I think that the reason is that on win10 NodeJS processes paths with backslashes. It can be fixed simply, we should use "slash" library for line 70 and 71. After these changes everything works fine for win10 and doesn't affect UNIX.

Thank you for considering this PR.